### PR TITLE
Fix font rendering inconsistencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "precommit": "pretty-quick --staged"
   },
   "dependencies": {
-    "@ibm/type": "^0.5.4",
     "alphabet": "^1.0.0",
     "autoprefixer": "^9.3.1",
     "browserslist": "^4.0.0",
@@ -40,6 +39,7 @@
     "react-dom": "^16.6.0",
     "rmwc": "^3.0.0",
     "sass-mq": "^4.0.2",
+    "typeface-ibm-plex-sans": "^0.0.61",
     "victory": "^0.27.0",
     "webpack": "^4.0.0"
   },

--- a/src/scss/_fonts.scss
+++ b/src/scss/_fonts.scss
@@ -1,81 +1,3 @@
-/* ibm-plex-sans-100normal - latin */
-@font-face {
-  font-family: 'ibm-plex-sans';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 100;
-  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-100.woff2')
-      format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-100.woff')
-      format('woff'); /* Modern Browsers */
-}
-
-/* ibm-plex-sans-100italic - latin */
-@font-face {
-  font-family: 'ibm-plex-sans';
-  font-style: italic;
-  font-display: swap;
-  font-weight: 100;
-  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-100italic.woff2')
-      format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-100italic.woff')
-      format('woff'); /* Modern Browsers */
-}
-
-/* ibm-plex-sans-200normal - latin */
-@font-face {
-  font-family: 'ibm-plex-sans';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 200;
-  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-200.woff2')
-      format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-200.woff')
-      format('woff'); /* Modern Browsers */
-}
-
-/* ibm-plex-sans-200italic - latin */
-@font-face {
-  font-family: 'ibm-plex-sans';
-  font-style: italic;
-  font-display: swap;
-  font-weight: 200;
-  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-200italic.woff2')
-      format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-200italic.woff')
-      format('woff'); /* Modern Browsers */
-}
-
-/* ibm-plex-sans-300normal - latin */
-@font-face {
-  font-family: 'ibm-plex-sans';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 300;
-  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-300.woff2')
-      format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-300.woff')
-      format('woff'); /* Modern Browsers */
-}
-
-/* ibm-plex-sans-300italic - latin */
-@font-face {
-  font-family: 'ibm-plex-sans';
-  font-style: italic;
-  font-display: swap;
-  font-weight: 300;
-  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-300italic.woff2')
-      format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-300italic.woff')
-      format('woff'); /* Modern Browsers */
-}
-
 /* ibm-plex-sans-400normal - latin */
 @font-face {
   font-family: 'ibm-plex-sans';
@@ -84,9 +6,8 @@
   font-weight: 400;
   src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-400.woff2')
       format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-400.woff')
-      format('woff'); /* Modern Browsers */
+    url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-400.woff')
+      format('woff');
 }
 
 /* ibm-plex-sans-400italic - latin */
@@ -97,61 +18,8 @@
   font-weight: 400;
   src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-400italic.woff2')
       format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-400italic.woff')
-      format('woff'); /* Modern Browsers */
-}
-
-/* ibm-plex-sans-500normal - latin */
-@font-face {
-  font-family: 'ibm-plex-sans';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 500;
-  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-500.woff2')
-      format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-500.woff')
-      format('woff'); /* Modern Browsers */
-}
-
-/* ibm-plex-sans-500italic - latin */
-@font-face {
-  font-family: 'ibm-plex-sans';
-  font-style: italic;
-  font-display: swap;
-  font-weight: 500;
-  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-500italic.woff2')
-      format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-500italic.woff')
-      format('woff'); /* Modern Browsers */
-}
-
-/* ibm-plex-sans-600normal - latin */
-@font-face {
-  font-family: 'ibm-plex-sans';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 600;
-  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-600.woff2')
-      format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-600.woff')
-      format('woff'); /* Modern Browsers */
-}
-
-/* ibm-plex-sans-600italic - latin */
-@font-face {
-  font-family: 'ibm-plex-sans';
-  font-style: italic;
-  font-display: swap;
-  font-weight: 600;
-  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-600italic.woff2')
-      format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-600italic.woff')
-      format('woff'); /* Modern Browsers */
+    url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-400italic.woff')
+      format('woff');
 }
 
 /* ibm-plex-sans-700normal - latin */
@@ -162,9 +30,8 @@
   font-weight: 700;
   src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-700.woff2')
       format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-700.woff')
-      format('woff'); /* Modern Browsers */
+    url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-700.woff')
+      format('woff');
 }
 
 /* ibm-plex-sans-700italic - latin */
@@ -175,7 +42,6 @@
   font-weight: 700;
   src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-700italic.woff2')
       format('woff2'),
-    /* Super Modern Browsers */
-      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-700italic.woff')
-      format('woff'); /* Modern Browsers */
+    url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-700italic.woff')
+      format('woff');
 }

--- a/src/scss/_fonts.scss
+++ b/src/scss/_fonts.scss
@@ -1,0 +1,181 @@
+/* ibm-plex-sans-100normal - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-100.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-100.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-100italic - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 100;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-100italic.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-100italic.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-200normal - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 200;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-200.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-200.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-200italic - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 200;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-200italic.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-200italic.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-300normal - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-300.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-300.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-300italic - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 300;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-300italic.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-300italic.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-400normal - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-400.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-400.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-400italic - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 400;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-400italic.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-400italic.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-500normal - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-500.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-500.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-500italic - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 500;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-500italic.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-500italic.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-600normal - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 600;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-600.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-600.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-600italic - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 600;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-600italic.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-600italic.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-700normal - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-700.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-700.woff')
+      format('woff'); /* Modern Browsers */
+}
+
+/* ibm-plex-sans-700italic - latin */
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 700;
+  src: url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-700italic.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('~typeface-ibm-plex-sans/files/ibm-plex-sans-latin-700italic.woff')
+      format('woff'); /* Modern Browsers */
+}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -14,7 +14,7 @@ $color-gray: #cccccc;
 $color-gray-light: #ececec;
 $color-gray-dark: #888888;
 
-$font-family-default: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+$font-family-default: 'ibm-plex-sans', 'Helvetica Neue', Arial, sans-serif;
 $font-size-default: 18px;
 $font-size-title: 22px;
 $font-size-accent: 15px;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -43,12 +43,7 @@
 @import '~@material/typography/mdc-typography';
 
 /**
- * Fonts
- */
-$font-prefix: '~@ibm/type';
-@import '~@ibm/type/scss/sans/index';
-
-/**
  * Baseline styling
  */
+@import 'fonts';
 @import 'baseline';


### PR DESCRIPTION
Closes #16 by using a [`typeface`](https://github.com/KyleAMathews/typefaces) package instead of the original IBM Plex font files.